### PR TITLE
Enable offline endpoint debugging and document the process

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,7 +5,7 @@ pre-requiste: node.js is already installed on your machine
 * The serverless.yml file is what you edit to manipulate endpoints and API Gateway
 * The node.js files in the server folder is what is used as the "server" code
 * You will need to set up an access key from AWS in order to deploy server code
-    * speak to a administator to obtain credentials to sign into AWS Console
+    * speak to a administrator to obtain credentials to sign into AWS Console
     * Sign In to AWS Console, navigate to `Academy of Cleaning` in the top nav > `My Security Credentials` and click `Create New Access Key`
     * follow instructions [here](https://www.serverless.com/framework/docs/providers/aws/guide/credentials#setup-with-serverless-config-credentials-command) to set up credentials
 * `cd` into the server dir and run `serverless deploy` to deploy code to the server to AWS
@@ -31,3 +31,9 @@ pre-requiste: node.js is already installed on your machine
 ## Deploying the Application
 * If you wish to deploy, push to the branch 'deploy-to-heroku' and our pipeline will run
 * A demo can be accessed here: https://serene-ocean-22768.herokuapp.com/
+
+## Testing the Application Locally
+To test the application locally:
+* `npm install serverless-offline`
+* `serverless offline`
+After you run the command, a list of viable endpoints will appear. Then just use the request mechanism of your choice (i.e Postman, `curl` etc.) to hit your endpoint.

--- a/server/serverless.yml
+++ b/server/serverless.yml
@@ -1,8 +1,7 @@
 service: AcademyOfCleaning
 
-# You can pin your service to only deploy with a specific Serverless version
-# Check out our docs for more details
-frameworkVersion: '2'
+plugins:
+  -  serverless-offline
 
 provider:
   name: aws


### PR DESCRIPTION
- This is not part of any story work but exists to expedite the development time of endpoints
- `serverless-offline` doesn't seem to work with the `frameworkVersion` mapping, not sure why. I tested and validated that it works with both serverless v2 and v1.87