### PR TITLE
added enum states and admin views

### DIFF
--- a/server/profile.js
+++ b/server/profile.js
@@ -9,8 +9,8 @@ const pool = new Pool({
 });
 
 // Application States
-const READY_FOR_VEFIFICATION = 'Application Pending Employer Validation';
-const VERIFIED = 'Application Completed Employer Validation';
+const READY_FOR_VEFIFICATION = 'More Info Required';
+const VERIFIED = 'Completed Validation';
 
 module.exports.getProfile = async (event) => {
 

--- a/server/profile.js
+++ b/server/profile.js
@@ -1,16 +1,37 @@
 const { Pool, Client } = require('pg')
 
 const pool = new Pool({
-  user: process.env.user,
-  host: process.env.host,
-  database: process.env.database,
-  password: process.env.password,
-  port: process.env.port,
+    user: process.env.user,
+    host: process.env.host,
+    database: process.env.database,
+    password: process.env.password,
+    port: process.env.port,
 });
+
+// Application States
+const READY_FOR_VEFIFICATION = 'Application Pending Employer Validation';
+const VERIFIED = 'Application Completed Employer Validation';
 
 module.exports.getProfile = async (event) => {
 
   let profileId = Number(event.queryStringParameters.id);
+  let verifiedState = Number(event.queryStringParameters.verified);
+  console.log(verifiedState)
+
+
+  /**
+   * Update the application state based on the type of call
+   */
+  let stateUpdate = "";
+  const appStatusUpdateSQL = 'UPDATE cleaner_profile SET app_status = $1 WHERE profile_id = $2';
+  if(verifiedState == 0){
+    const readyToVerifyValues = [READY_FOR_VEFIFICATION, profileId]
+    stateUpdate = await pool.query(appStatusUpdateSQL, readyToVerifyValues);
+  } 
+  if(verifiedState == 1){
+    const inProgressValues = [VERIFIED, profileId]
+    stateUpdate = await pool.query(appStatusUpdateSQL, inProgressValues);
+  }
 
   const selectProfile = "SELECT * FROM cleaner_profile WHERE profile_id = $1";
   const values = [profileId]

--- a/server/profile.js
+++ b/server/profile.js
@@ -16,8 +16,6 @@ module.exports.getProfile = async (event) => {
 
   let profileId = Number(event.queryStringParameters.id);
   let verifiedState = Number(event.queryStringParameters.verified);
-  console.log(verifiedState)
-
 
   /**
    * Update the application state based on the type of call

--- a/server/profileFormUpdate.js
+++ b/server/profileFormUpdate.js
@@ -2,6 +2,7 @@ const { Pool } = require('pg');
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
+//DB connection Information 
 const pool = new Pool({ 
     user: process.env.user,
     host: process.env.host,
@@ -17,11 +18,16 @@ s3.config.update({
 });
 
 //TODO: change the actual PRIVATE_BUCKET name, for whatever reason AWS wasn't working properly and I couldn't change it
+// AWS bucket names
 const LICENSE_BUCKET = "cleaner-licenses";
 const TOOLS_BUCKET = "semi-private";
-
 let s3Urls = ['',''];
 
+//Application Status Names:
+const IN_PROGRESS = 'Began Application';
+const READY_FOR_VEFIFICATION = 'Application Pending Employer Validation';
+
+/** Build out the s3 bucket URL */
 const s3Params = (bucket_name, documentType, profileId) => {
     return {
         ACL: 'public-read',
@@ -32,15 +38,35 @@ const s3Params = (bucket_name, documentType, profileId) => {
 }
 
 module.exports.editProfile = async (event, callback )=> {
-    const body = JSON.parse(event.body);
-    const text = 'UPDATE cleaner_profile SET(first_name, last_name, contact_num, email, has_tools) = ($1, $2, $3, $4, $5) WHERE profile_id = $6'
-    const values = [body.firstName, body.lastName, body.number, body.email, body.toolPic, body.id]
+    const responseBody = JSON.parse(event.body);
 
-    const result = await pool.query(text, values);
+    /**
+     * Update the profile 
+     */
+    const sqlProfileUpdate = 'UPDATE cleaner_profile SET(first_name, last_name, contact_num, email, has_tools) = ($1, $2, $3, $4, $5) WHERE profile_id = $6'
+    const dbValuesToBeUpdated = [responseBody.firstName, responseBody.lastName, responseBody.number, responseBody.email, responseBody.toolPic, responseBody.id]
+    const result = await pool.query(sqlProfileUpdate, dbValuesToBeUpdated);
 
-    let profileId = body.id;
-    let govId = body.govId;
-    let toolPic = body.toolPic;
+    /**
+     * Update the application state based on the type of call if param is included
+     */
+    let stateUpdate = "";
+    const appStatusUpdateSQL = 'UPDATE cleaner_profile SET app_status = $1 WHERE profile_id = $2';
+    if(responseBody.readyForVerification == 1){
+      const readyToVerifyValues = [READY_FOR_VEFIFICATION, responseBody.id]
+      stateUpdate = await pool.query(appStatusUpdateSQL, readyToVerifyValues);
+    } 
+    if(responseBody.readyForVerification == 0){
+      const inProgressValues = [IN_PROGRESS, responseBody.id]
+      stateUpdate = await pool.query(appStatusUpdateSQL, inProgressValues);
+    }
+
+    /**
+     * Update the files 
+     */
+    let profileId = responseBody.id;
+    let govId = responseBody.govId;
+    let toolPic = responseBody.toolPic;
     s3Urls[0] = govId == true ? s3.getSignedUrl('putObject', s3Params(LICENSE_BUCKET, "licenses", profileId)) : '';
     s3Urls[1] = toolPic == true ? s3.getSignedUrl('putObject', s3Params(TOOLS_BUCKET, "tool pics", profileId)): '';
 

--- a/server/profileFormUpdate.js
+++ b/server/profileFormUpdate.js
@@ -25,7 +25,7 @@ let s3Urls = ['',''];
 
 //Application Status Names:
 const IN_PROGRESS = 'Began Application';
-const READY_FOR_VEFIFICATION = 'Application Pending Employer Validation';
+const READY_FOR_VEFIFICATION = 'Pending Validation';
 
 /** Build out the s3 bucket URL */
 const s3Params = (bucket_name, documentType, profileId) => {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12478,6 +12478,11 @@
         }
       }
     },
+    "stringquery": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/stringquery/-/stringquery-1.0.8.tgz",
+      "integrity": "sha512-KqKh5OwkldIrG6TRAlOU02EIdvjC2A4LAGVvVyoDXRRTl0224naoKMRBf+uzPFdXE2+rcHVh2NKTznbsn+AzFw=="
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.0",
     "reactstrap": "^8.6.0",
+    "stringquery": "^1.0.8",
     "styled-components": "^5.2.1"
   },
   "scripts": {

--- a/ui/src/Components/EditProfile.jsx
+++ b/ui/src/Components/EditProfile.jsx
@@ -274,8 +274,8 @@ class CreateProfile extends React.Component {
                             </Col>
                         </FormGroup>
                         <FormGroup className="right-align" check row>
-                            <Button type="submit" name="false" onClick={this.handleAppStatusUpdate}>{uploadCopy}</Button>
-                            <Button type="submit" name="true" onClick={this.handleAppStatusUpdate}>{readyForVerificationCopy}</Button>
+                            <Button type="submit" name="false" onClick={this.handleAppStatusUpdate } style={{margin: '5px'}}>{uploadCopy}</Button> 
+                            <Button type="submit" name="true" onClick={this.handleAppStatusUpdate} style={{backgroundColor: '#4CAF50'}}>{readyForVerificationCopy}</Button>
                         </FormGroup>
                         </div>
                     </Form>

--- a/ui/src/Components/EditProfile.jsx
+++ b/ui/src/Components/EditProfile.jsx
@@ -2,11 +2,20 @@ import React from 'react';
 import { Button, Col, Form, FormGroup, Label, Input} from 'reactstrap';
 import { Loading } from './auth/Loading';
 
-//Uncomment/Comment based on env
+//URLs for PUT CALL
 // const ApiUrl = "http://localhost:3001/dev/editProfile";
 const ApiUrl = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/editProfile";
-const GetApiUrl = `https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/viewProfile?id=`;
 
+//URLS for GET CALL
+const GetApiUrl = `https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/viewProfile?id=`;
+// const GetApiUrl = "http://localhost:3001/dev/viewProfile?id="
+
+// URLS for Files 
+const toolPicUrl = 'https://cleaner-tool-pics.s3-us-west-1.amazonaws.com/'
+
+// COPIES FOR REACT CLIENT 
+const readyForVerificationCopy = "Submit";
+const uploadCopy = "Save";
 
 class CreateProfile extends React.Component {
     constructor(props) {
@@ -29,6 +38,7 @@ class CreateProfile extends React.Component {
             govId: null,
             toolPicFlag: false,
             toolPic: null,
+            readyForVerification:0,
         };
 
         this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
@@ -41,11 +51,12 @@ class CreateProfile extends React.Component {
         this.handleRef1EmailChange = this.handleRef2EmailChange.bind(this);
         this.handleLicenseUpload = this.handleLicenseUpload.bind(this);
         this.handleToolUpload = this.handleToolUpload.bind(this);
+        this.handleAppStatusUpdate = this.handleAppStatusUpdate.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
 
     }
 
-    // function to get new information 
+    // Get information to populate the profile before editing
     async componentDidMount()
     {
       const url = GetApiUrl+this.state.props.match.params.id;
@@ -62,6 +73,14 @@ class CreateProfile extends React.Component {
     // functions to handle method update
     handleFirstNameChange(event) {
         this.setState({firstName: event.target.value});
+    }
+
+    handleAppStatusUpdate(event){
+        if(event.target.name == "true"){
+            this.setState({readyForVerification: 1});
+        } else {
+            this.setState({readyForVerification: 0});
+        }
     }
 
     handleLastNameChange(event) {
@@ -122,7 +141,6 @@ class CreateProfile extends React.Component {
         }  
     };
 
-    /** NEW API to be set - PUT request that updates the Entry!*/
     handleSubmit(event) {
         this.checkIfBlank();
         event.preventDefault();
@@ -145,6 +163,7 @@ class CreateProfile extends React.Component {
                 govId:this.state.govIdFlag,
                 toolPic:this.state.toolPicFlag,
                 id:this.state.props.match.params.id, //added profile ID to payload
+                readyForVerification: this.state.readyForVerification,
                 }),
             })
             .then(res => res.json())
@@ -176,9 +195,9 @@ class CreateProfile extends React.Component {
     
     render() {
         const checkToolFile = ()=>{
-            if(this.state.toolPicUrl!==''){
+            if(this.state.profile.result.has_tools){
                 // Currently displays "Took Pic File Uploaded" above the field, which seems incorrect. Until clarification, commenting out.
-                // return <a href={this.state.toolPicUrl}> Tool Pic File Uploaded </a>
+                return <a target="_blank" href={toolPicUrl + this.state.props.match.params.id + '.pdf'}>Tool Picture Link</a>
             } 
         }
         if (this.state.loading) {
@@ -255,7 +274,8 @@ class CreateProfile extends React.Component {
                             </Col>
                         </FormGroup>
                         <FormGroup className="right-align" check row>
-                            <Button type="submit">Save</Button>
+                            <Button type="submit" name="false" onClick={this.handleAppStatusUpdate}>{uploadCopy}</Button>
+                            <Button type="submit" name="true" onClick={this.handleAppStatusUpdate}>{readyForVerificationCopy}</Button>
                         </FormGroup>
                         </div>
                     </Form>

--- a/ui/src/Components/ProfilePage.jsx
+++ b/ui/src/Components/ProfilePage.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Form, Table, Button } from 'reactstrap';
+import { Form, Table, Button, FormGroup } from 'reactstrap';
 import { Link } from 'react-router-dom';
 import { Loading } from './auth/Loading';
+import querySearch from "stringquery";
+
+const URL = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/viewProfile?";
+// const URL = "http://localhost:3001/dev/viewProfile?"
 
 /* Illustration of how to use a styled component 
   1. create a styled component with the given syntax
@@ -33,18 +37,66 @@ export default class ProfilePage extends React.Component {
       loading: true,
       profile: null,
       props: props,
+      admin:false,
+      verified:0,
     }
+
+    this.handleReadyParam = this.handleReadyParam.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   async componentDidMount()
   {
-    const url = `https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/viewProfile?id=${this.state.props.match.params.id}`;
+    const url = URL + `id=${this.state.props.match.params.id}`;
     const resp = await fetch(url);
     const data = await resp.json();
-    this.setState({profile: data, loading: false});
+    var adminState = querySearch(this.props.location.search).admin;
+    this.setState({profile: data, loading: false, admin: adminState});
   }
 
+  handleReadyParam(event){
+    if(event.target.name === "true"){
+      this.setState({verified: 1});
+    } else{
+      this.setState({verified: 0});
+    }
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const url = URL + `id=${this.state.props.match.params.id}&verified=${this.state.verified}`;
+    fetch(url)
+    .then(res => res.json())
+    .then(res => {
+      this.setState({profile: res})
+    })
+    this.render()
+};
+
   render(){
+    const editOrValidateCTAs = ()=>{
+      if(this.state.admin == 1){ //validate CTAs displayed
+          // Currently displays "Took Pic File Uploaded" above the field, which seems incorrect. Until clarification, commenting out.
+          return(
+            <div>
+              <Form onSubmit={ this.handleSubmit }>
+                <div className="row-buffer side-buffer">
+                  <FormGroup className="right-align" check row>
+                    <Button type="submit" name="false" onClick={this.handleReadyParam}>Pending Verification</Button>
+                    <Button type="submit" name="true" onClick={this.handleReadyParam}>Verified</Button>
+                  </FormGroup>
+                </div>
+              </Form>
+            </div>
+          ) 
+      } else{ //edit profile CTA
+        return (
+          <div className="right-align">
+            <Link to= {`/profiles/edit/${this.state.profile.result.profile_id}`}className="btn btn-secondary">Edit this profile</Link>
+          </div>
+        )
+      }
+  }
     if (this.state.loading == true) {
       return(
        <Loading/> 
@@ -86,16 +138,15 @@ export default class ProfilePage extends React.Component {
                   ) : <div/>}
                   <tr>
                     <td>Id Verified</td>
-                    {this.state.profile.result.gov_id ? <td>Verified</td> : <td>Not Verified</td> }
+                  {/* must be updated in the GET ticket to import the state directly from the DB */}
+                    <td>{this.state.profile.result.app_status}</td>
                   </tr>
                 </tbody>
               </Table>
-              <div className="right-align">
-                <Link to= {`/profiles/edit/${this.state.profile.result.profile_id}`}className="btn btn-secondary">Edit this profile</Link>
-              </div>
             </div>
           )}
         </Form>
+        {editOrValidateCTAs()}
         
       </div>
     );

--- a/ui/src/Components/ProfilePage.jsx
+++ b/ui/src/Components/ProfilePage.jsx
@@ -41,7 +41,7 @@ export default class ProfilePage extends React.Component {
       verified:0,
     }
 
-    this.handleReadyParam = this.handleReadyParam.bind(this);
+    this.handlePendingVerParam = this.handlePendingVerParam.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
@@ -54,7 +54,7 @@ export default class ProfilePage extends React.Component {
     this.setState({profile: data, loading: false, admin: adminState});
   }
 
-  handleReadyParam(event){
+  handlePendingVerParam(event){
     if(event.target.name === "true"){
       this.setState({verified: 1});
     } else{
@@ -81,9 +81,10 @@ export default class ProfilePage extends React.Component {
             <div>
               <Form onSubmit={ this.handleSubmit }>
                 <div className="row-buffer side-buffer">
+                  <p className="right-align">Applicant Status:</p>
                   <FormGroup className="right-align" check row>
-                    <Button type="submit" name="false" onClick={this.handleReadyParam}>Pending Verification</Button>
-                    <Button type="submit" name="true" onClick={this.handleReadyParam}>Verified</Button>
+                    <Button type="submit" name="false" onClick={this.handlePendingVerParam} style={{margin: '5px'}}>More Information Required</Button>
+                    <Button type="submit" name="true" onClick={this.handlePendingVerParam} style={{backgroundColor: '#4CAF50'}}>Verify Candidate</Button>
                   </FormGroup>
                 </div>
               </Form>

--- a/ui/src/Components/ProfilePage.jsx
+++ b/ui/src/Components/ProfilePage.jsx
@@ -92,9 +92,12 @@ export default class ProfilePage extends React.Component {
           ) 
       } else{ //edit profile CTA
         return (
-          <div className="right-align">
+          <Form>
+            <div className="right-align" style={{marginRight: '100px'}}>
             <Link to= {`/profiles/edit/${this.state.profile.result.profile_id}`}className="btn btn-secondary">Edit this profile</Link>
-          </div>
+            </div>
+          </Form>
+
         )
       }
   }

--- a/ui/src/Components/SearchCandidates.jsx
+++ b/ui/src/Components/SearchCandidates.jsx
@@ -46,7 +46,7 @@ export default class SearchCandidates extends React.Component {
 	populate = (items, obj, i)=> {
 		items.push(<tr>
 			<th scope="row">{i+1}</th>
-			<td ><a href={"/profiles/"+obj[i].profile_id}>{obj[i].first_name} {obj[i].last_name}</a></td>
+			<td ><a href={"/profiles/"+obj[i].profile_id+"?admin=1"}>{obj[i].first_name} {obj[i].last_name}</a></td>
 			<td>{obj[i].email}</td>
 			<td>{obj[i].contact_num}</td>
 		</tr>)


### PR DESCRIPTION
- view Profile has an admin view now
- GET API now updates app state (verified and pending)
- PUT API now updates app state (between in progress and pending)
- search routes to admin view

What needs to happen:
In edit profile:
1. add a save button 
2. add a submit button
3. API willl need a new param that will determine if we are setting the application as Pending Verification or Application in Progress (will change depending on if save or submit was clicked)

View Profile:
1. we will accept a query param of admin=true and if bool is present a new API will be available that will POST the state as verified or pending. 
1b. verification form to be made (2 buttons - verify and unverify) 
2. GET API will be refactored

Search View:
1. Update the hyperlink to pass in admin query param 

Demo: https://drive.google.com/file/d/1ERp-dyZx2rE1lSBCS7Rf44jv5G8ZvMCv/view?usp=sharing

Business Logic:
- [x] I can toggle my profile from began app to pending verification by clicking save/submit respectively
- [x] accessing a profile from the search page will allow me to toggle a profile between verified and pending 
- [x] search page profile URLs will show the admin buttons (not editing buttons) whereas all other cases show (personal profile editing)