### PR TITLE
Update create profile view and endpoint to include updated data

### DIFF
--- a/server/profileFormSubmission.js
+++ b/server/profileFormSubmission.js
@@ -34,16 +34,45 @@ const s3Params = (bucket_name, documentType, profileId) => {
 
 module.exports.saveProfile = async (event, callback )=> {
   const body = JSON.parse(event.body);
-  const text = 'INSERT INTO cleaner_profile(first_name, last_name, contact_num, email, has_tools) VALUES($1, $2, $3, $4, $5) RETURNING *'
-  const values = [body.firstName, body.lastName, body.number, body.email, body.toolPic];
+  console.log(body)
+  const cleanerStatement = 'INSERT INTO cleaner_profile(first_name, middle_name, last_name, address, city, postal_code, province, dob, current_occup, contact_num, email, has_tools) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *'
+  const cleanerValues = [body.firstName, body.middleName, body.lastName, body.address, body.city, body.postal, body.province, body.dob, body.currentOccupation, body.number, body.email, body.toolPic];
+  const result = await pool.query(cleanerStatement, cleanerValues);
 
-    const result = await pool.query(text, values);
+  let profileId = result.rows[0].profile_id;
 
-    let profileId = result.rows[0].profile_id;
-    let govId = body.govId;
-    let toolPic = body.toolPic;
+  const refInsertStatement = 'INSERT INTO reference(first_name, last_name, email, contact_num, relationship) VALUES ($1, $2, $3, $4, $5) RETURNING ref_id'
+  const hasRefInsertStatement = 'INSERT INTO has_ref(profile_id, ref_id) VALUES ($1, $2)'
+  if (body.reference1Name) {
+    console.log("in ref 1 block")
+    let name = body.reference1Name.split(" ")
+    const ref1Values = [name[0], name[1], body.reference1Email, "647-781-1815", body.reference1Relationship]
+    const ref1Result = await pool.query(refInsertStatement, ref1Values) 
+    let ref1Id = ref1Result.rows[0].ref_id
+    await pool.query(hasRefInsertStatement, [profileId, ref1Id])
+    .catch(err => console.log(err))
+  }
+
+  if (body.reference2Name) {
+    console.log("in ref 2 block")
+    let name = body.reference2Name.split(" ")
+    const ref2Values = [name[0], name[1], body.reference2Email, "905-334-1458", body.reference2Relationship]
+    const ref2Result = await pool.query(refInsertStatement, ref2Values) 
+    let ref2Id = ref2Result.rows[0].ref_id
+    await pool.query(hasRefInsertStatement, [profileId, ref2Id])
+    .catch(err => console.log(err))
+  }
+  
+  // insert into references, return refernce id, put refid and profile_id into has reference
+
+  let govId = body.govId;
+  let toolPic = body.toolPic;
+    //let hin = body.hin
+
     s3Urls[0] = govId == true ? s3.getSignedUrl('putObject', s3Params(LICENSE_BUCKET, "licenses", profileId)) : '';
     s3Urls[1] = toolPic == true ? s3.getSignedUrl('putObject', s3Params(TOOLS_BUCKET, "tool pics", profileId)): '';
+    /* To implement HIN, just uncomment the below line */
+    //s3Urls[2] = hin == true ? s3.getSignedUrl('putObject', s3Params(TOOLS_BUCKET, "tool pics", profileId)): '';
 
     return {
       statusCode: 200,

--- a/server/profileFormUpdate.js
+++ b/server/profileFormUpdate.js
@@ -35,10 +35,13 @@ const s3Params = (bucket_name, documentType, profileId) => {
         ContentType: 'application/pdf',
         Key: `${documentType}/${profileId}.pdf`,
     }
-}
+} 
 
 module.exports.editProfile = async (event, callback )=> {
-    const responseBody = JSON.parse(event.body);
+    const body = JSON.parse(event.body);
+    const text = 'UPDATE cleaner_profile SET(first_name, middle_name, last_name, address, city, postal_code, province, dob, current_occup, contact_num, email, has_tools) = ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) WHERE profile_id = $13'
+    const values = [body.firstName, body.middleName, body.lastName, body.address, body.city, body.postal, body.province, body.dob, body.currentOccupation, body.number, body.email, body.toolPic, body.id]
+
 
     /**
      * Update the profile 

--- a/ui/src/Components/CreateProfile.jsx
+++ b/ui/src/Components/CreateProfile.jsx
@@ -4,40 +4,94 @@ import { Button, Col, Form, FormGroup, Label, Input} from 'reactstrap';
 import './App.css';
 
 //Uncomment/Comment based on env
-const URL = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/insertFormData";
-//const URL = "http://localhost:3000/dev/insertFormData";
+//const URL = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/insertFormData";
+const URL = "http://localhost:3001/dev/insertFormData";
 
 class CreateProfile extends React.Component {
     constructor(props) {
         super(props);
-
+        
         this.state = {
             firstName: '',
+            middleName: '',
             lastName: '',
             email: '',
+            address: '',
+            city: '',
+            postal: '',
+            province: '',
+            dob: '',
             number: '',
             profile_id: '',
+            sin: '',
+            currentOccupation: '',
             ref1Name: '',
             ref1Email: '',
+            ref1Relationship: '',
             ref2Name: '',
             ref2Email: '',
+            ref2Relationship: '',
             govIdFlag: false,
             govId: null,
             toolPicFlag: false,
             toolPic: null,
+            hinFlag: false,
+            hinPic: null,
         };
 
         this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
+        this.handleMiddleNameChange = this.handleMiddleNameChange.bind(this);
         this.handleLastNameChange = this.handleLastNameChange.bind(this);
         this.handleEmailChange = this.handleEmailChange.bind(this);
+        this.handleAddressChange = this.handleAddressChange.bind(this);
+        this.handleCityChange = this.handleCityChange.bind(this);
+        this.handlePostalChange = this.handlePostalChange.bind(this);
+        this.handleProvinceChange = this.handleProvinceChange.bind(this);
+        this.handleDobChange = this.handleDobChange.bind(this);
+        this.handleSinChange = this.handleSinChange.bind(this);
+        this.handleCurrentOccupationChange = this.handleCurrentOccupationChange.bind(this);
         this.handleNumChange = this.handleNumChange.bind(this);
         this.handleRef1NameChange = this.handleRef1NameChange.bind(this);
         this.handleRef1EmailChange = this.handleRef1EmailChange.bind(this);
+        this.handleRef1RelationshipChange = this.handleRef1RelationshipChange.bind(this);
         this.handleRef2NameChange = this.handleRef2NameChange.bind(this);
         this.handleRef2EmailChange = this.handleRef2EmailChange.bind(this);
+        this.handleRef2RelationshipChange = this.handleRef2RelationshipChange.bind(this);
         this.handleLicenseUpload = this.handleLicenseUpload.bind(this);
         this.handleToolUpload = this.handleToolUpload.bind(this);
+        this.handleHinUpload = this.handleHinUpload.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleSinChange(event) {
+        this.setState({sin: event.target.value});
+    }
+    handleCurrentOccupationChange(event) {
+        this.setState({currentOccupation: event.target.value});
+    }
+
+    handleDobChange(event) {
+        this.setState({dob: event.target.value});
+    }
+
+    handleProvinceChange(event) {
+        this.setState({province: event.target.value});
+    }
+
+    handlePostalChange(event) {
+        this.setState({postal: event.target.value});
+    }
+
+    handleCityChange(event) {
+        this.setState({city: event.target.value});
+    }
+    
+    handleAddressChange(event) {
+        this.setState({address: event.target.value});
+    }
+
+    handleMiddleNameChange(event) {
+        this.setState({middleName: event.target.value});
     }
 
     handleFirstNameChange(event) {
@@ -72,6 +126,14 @@ class CreateProfile extends React.Component {
         this.setState({ref2Email: event.target.value});
     }
 
+    handleRef1RelationshipChange(event) {
+        this.setState({ref1Relationship: event.target.value});
+    }
+
+    handleRef2RelationshipChange(event) {
+        this.setState({ref2Relationship: event.target.value});
+    }
+
     handleLicenseUpload(event) {
         this.setState({
             govIdFlag: true,
@@ -83,6 +145,13 @@ class CreateProfile extends React.Component {
         this.setState({
             toolPicFlag: true,
             toolPic: event.target.files[0]
+        });
+    }
+    
+    handleHinUpload(event) {
+        this.setState({
+            hinFlag: true,
+            hinPic: event.target.files[0]
         });
     }
 
@@ -97,15 +166,26 @@ class CreateProfile extends React.Component {
                 },
               body: JSON.stringify( { 
                 firstName:this.state.firstName, 
+                middleName:this.state.middleName, 
                 lastName:this.state.lastName,
-                email:this.state.email, 
-                number:this.state.number, 
+                address:this.state.address,
+                city:this.state.city,
+                postal: this.state.postal,
+                province: this.state.province,
+                dob: this.state.dob,
+                sin: this.state.sin,
+                currentOccupation: this.state.currentOccupation,
+                email: this.state.email, 
+                number: this.state.number, 
                 reference1Name:this.state.ref1Name,
                 reference1Email:this.state.ref1Email,
+                reference1Relationship:this.state.ref1Relationship,
                 reference2Name:this.state.ref2Name,
                 reference2Email:this.state.ref2Email,
+                reference2Relationship:this.state.ref2Relationship,
                 govId:this.state.govIdFlag,
-                toolPic:this.state.toolPicFlag
+                toolPic:this.state.toolPicFlag,
+                hinFlag:this.state.hinFlag
                 }),
             })
             .then(res => res.json())
@@ -152,13 +232,30 @@ class CreateProfile extends React.Component {
                     <Label for="firstName" sm={2}>First Name</Label>
                     <Col sm={10}>
                     <AvField name="firstName" type="text" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName} required />
-                    {/* <Input type="text" name="name" id="firstname" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName}/> */}
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="middleName" sm={2}>Middle Name</Label>
+                    <Col sm={10}>
+                    <AvField name="middleName" type="text" placeholder="Doe" onChange={this.handleMiddleNameChange} value={this.state.middleName} required />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
                     <Label for="lastName" sm={2}>Last Name</Label>
                     <Col sm={10}>
-                    <AvField name="lastName" type="text" placeholder="Doe" onChange={this.handleLastNameChange} value={this.state.lastName} required />
+                    <AvField name="lastName" type="text" placeholder="Arelli" onChange={this.handleLastNameChange} value={this.state.lastName} required />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="dob" sm={2}>Date of Birth</Label>
+                    <Col sm={10}>
+                    <AvField name="dob" type="date" placeholder="mm/dd/yyyy" onChange={this.handleDobChange} value={this.state.dob} required />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="sin" sm={2}>Social Insurance Number</Label>
+                    <Col sm={10}>
+                    <AvField name="sin" type="number" placeholder="123456789" maxLength={9} minLength={9} onChange={this.handleSinChange} value={this.state.sin} required />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
@@ -174,31 +271,76 @@ class CreateProfile extends React.Component {
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
-                    <Label for="govId" sm={2}>Government Issued ID</Label>
+                    <Label for="address" sm={2}>Address</Label>
                     <Col sm={10}>
-                    <AvField name="govId" type="file" onChange={this.handleLicenseUpload} />
+                    <AvField name="address" type="text" placeholder="100 Reindeer Street" onChange={this.handleAddressChange} value={this.state.address} required />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
+                    <Label for="city" sm={2}>City</Label>
+                    <Col sm={10}>
+                    <AvField name="city" type="text" placeholder="North Pole" onChange={this.handleCityChange} value={this.state.city} required />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="postal" sm={2}>Postal Code</Label>
+                    <Col sm={10}>
+                    <AvField name="postal" type="text" placeholder="H0H 0H0" onChange={this.handlePostalChange} value={this.state.postal} required />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="province" sm={2}>Province</Label>
+                    <Col sm={10}>
+                    <AvField name="province" type="text" placeholder="Arctic Circle" onChange={this.handleProvinceChange} value={this.state.province} required />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="currentOccupation" sm={2}>Current Occupation</Label>
+                    <Col sm={10}>
+                    <AvField name="currentOccupation" type="text" placeholder="Student" onChange={this.handleCurrentOccupationChange} value={this.state.currentOccupation} required />
+                    </Col>
+                </FormGroup>
+                
+                <FormGroup className="left-align" row>
                     <Label sm={2}>Reference 1:</Label>
-                    <Label for="referenceName" sm={1}>Name</Label>
-                    <Col sm={4}>
+                    <Label for="ref1Name" sm={1}>Name</Label>
+                    <Col sm={2}>
                     <Input type="text" name="ref1Name" id="referenceName" onChange={this.handleRef1NameChange} value={this.state.ref1Name}/>
                     </Col>
-                    <Label for="referenceEmail" sm={1}>Email</Label>
-                    <Col sm={4}>
+                    <Label for="ref1Email" sm={1}>Email</Label>
+                    <Col sm={2}>
                     <Input type="email" name="ref1Email" id="referenceEmail" onChange={this.handleRef1EmailChange} value={this.state.ref1Email}/>
+                    </Col>
+                    <Label for="ref1Relationship" sm={1}>Relationship</Label>
+                    <Col sm={2}>
+                    <Input type="text" name="ref1Email" id="referenceRelationship" onChange={this.handleRef1RelationshipChange} value={this.state.ref1Relationship}/>
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
                     <Label sm={2}>Reference 2:</Label>
                     <Label for="ref2Name" sm={1}>Name</Label>
-                    <Col sm={4}>
+                    <Col sm={2}>
                     <Input type="text" name="ref2Name" id="referenceName" onChange={this.handleRef2NameChange} value={this.state.ref2Name}/>
                     </Col>
                     <Label for="ref2Email" sm={1}>Email</Label>
-                    <Col sm={4}>
+                    <Col sm={2}>
                     <Input type="email" name="ref2Email" id="referenceEmail" onChange={this.handleRef2EmailChange} value={this.state.ref2Email}/>
+                    </Col>
+                    <Label for="ref2Relationship" sm={1}>Relationship</Label>
+                    <Col sm={2}>
+                    <Input type="text" name="ref2Relationship" id="referenceRelationship" onChange={this.handleRef2RelationshipChange} value={this.state.ref2Relationship}/>
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="hin" sm={2}>Proof of Health Insurance</Label>
+                    <Col sm={10}>
+                    <AvField name="hin" type="file" onChange={this.handleHinUpload} />
+                    </Col>
+                </FormGroup>
+                <FormGroup className="left-align" row>
+                    <Label for="govId" sm={2}>Government Issued ID</Label>
+                    <Col sm={10}>
+                    <AvField name="govId" type="file" onChange={this.handleLicenseUpload} />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>

--- a/ui/src/Components/CreateProfile.jsx
+++ b/ui/src/Components/CreateProfile.jsx
@@ -34,11 +34,10 @@ class CreateProfile extends React.Component {
         this.handleRef1NameChange = this.handleRef1NameChange.bind(this);
         this.handleRef1EmailChange = this.handleRef1EmailChange.bind(this);
         this.handleRef2NameChange = this.handleRef2NameChange.bind(this);
-        this.handleRef1EmailChange = this.handleRef2EmailChange.bind(this);
+        this.handleRef2EmailChange = this.handleRef2EmailChange.bind(this);
         this.handleLicenseUpload = this.handleLicenseUpload.bind(this);
         this.handleToolUpload = this.handleToolUpload.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-
     }
 
     handleFirstNameChange(event) {
@@ -111,7 +110,8 @@ class CreateProfile extends React.Component {
             })
             .then(res => res.json())
             .then(res => {
-                res = JSON.parse(res.body)
+                // console.log(res);
+                // res = JSON.parse(res.body)
                 if (res.govIdUrl!=='') {
                     fetch(res.govIdUrl, {
                         method: "PUT",
@@ -146,19 +146,19 @@ class CreateProfile extends React.Component {
             <AvForm onSubmit={ this.handleSubmit }>
                 <div class="row-buffer side-buffer">
                 <FormGroup row>
-                <Label for="name" sm={2}><h4 className="left-align" >Complete Profile</h4></Label>
+                <Label sm={2}><h4 className="left-align" >Complete Profile</h4></Label>
                 </FormGroup>
                 <FormGroup className="left-align" row>
-                    <Label for="name" sm={2}>First Name</Label>
+                    <Label for="firstName" sm={2}>First Name</Label>
                     <Col sm={10}>
-                    <AvField name="name" type="text" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName} required />
+                    <AvField name="firstName" type="text" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName} required />
                     {/* <Input type="text" name="name" id="firstname" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName}/> */}
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
-                    <Label for="name" sm={2}>Last Name</Label>
+                    <Label for="lastName" sm={2}>Last Name</Label>
                     <Col sm={10}>
-                    <AvField name="name" type="text" placeholder="Doe" onChange={this.handleLastNameChange} value={this.state.lastName} required />
+                    <AvField name="lastName" type="text" placeholder="Doe" onChange={this.handleLastNameChange} value={this.state.lastName} required />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
@@ -168,9 +168,9 @@ class CreateProfile extends React.Component {
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
-                    <Label for="phone" sm={2}>Phone Number</Label>
+                    <Label for="number" sm={2}>Phone Number</Label>
                     <Col sm={10}>
-                    <AvField name="phone" type="tel" placeholder="415-879-7877" onChange={this.handleNumChange} value={this.state.number} required />
+                    <AvField name="number" type="tel" placeholder="415-879-7877" onChange={this.handleNumChange} value={this.state.number} required />
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
@@ -183,22 +183,22 @@ class CreateProfile extends React.Component {
                     <Label sm={2}>Reference 1:</Label>
                     <Label for="referenceName" sm={1}>Name</Label>
                     <Col sm={4}>
-                    <Input type="text" name="referenceName" id="referenceName" onChange={this.handleRef1NameChange} value={this.state.ref1Name}/>
+                    <Input type="text" name="ref1Name" id="referenceName" onChange={this.handleRef1NameChange} value={this.state.ref1Name}/>
                     </Col>
                     <Label for="referenceEmail" sm={1}>Email</Label>
                     <Col sm={4}>
-                    <Input type="email" name="referenceEmail" id="referenceEmail" onChange={this.handleRef1EmailChange} value={this.state.ref1Email}/>
+                    <Input type="email" name="ref1Email" id="referenceEmail" onChange={this.handleRef1EmailChange} value={this.state.ref1Email}/>
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>
                     <Label sm={2}>Reference 2:</Label>
-                    <Label for="referenceName" sm={1}>Name</Label>
+                    <Label for="ref2Name" sm={1}>Name</Label>
                     <Col sm={4}>
-                    <Input type="text" name="referenceName" id="referenceName" onChange={this.handleRef2NameChange} value={this.state.ref2Name}/>
+                    <Input type="text" name="ref2Name" id="referenceName" onChange={this.handleRef2NameChange} value={this.state.ref2Name}/>
                     </Col>
-                    <Label for="referenceEmail" sm={1}>Email</Label>
+                    <Label for="ref2Email" sm={1}>Email</Label>
                     <Col sm={4}>
-                    <Input type="email" name="referenceEmail" id="referenceEmail" onChange={this.handleRef2EmailChange} value={this.state.ref2Email}/>
+                    <Input type="email" name="ref2Email" id="referenceEmail" onChange={this.handleRef2EmailChange} value={this.state.ref2Email}/>
                     </Col>
                 </FormGroup>
                 <FormGroup className="left-align" row>

--- a/ui/src/Components/CreateProfile.jsx
+++ b/ui/src/Components/CreateProfile.jsx
@@ -4,8 +4,8 @@ import { Button, Col, Form, FormGroup, Label, Input} from 'reactstrap';
 import './App.css';
 
 //Uncomment/Comment based on env
-//const URL = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/insertFormData";
-const URL = "http://localhost:3001/dev/insertFormData";
+const URL = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/insertFormData";
+//const URL = "http://localhost:3001/dev/insertFormData";
 
 class CreateProfile extends React.Component {
     constructor(props) {

--- a/ui/src/Components/Dropdown.jsx
+++ b/ui/src/Components/Dropdown.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+} from 'reactstrap';
+
+const Dropdown = () => (
+    <React.Fragment>
+    <DropdownToggle nav caret>
+                My Account
+              </DropdownToggle>
+              <DropdownMenu right>
+                <DropdownItem href="/profiles/:id">
+                  Edit info
+                </DropdownItem>
+                <DropdownItem href="/profiles/preferences/:id">
+                  View preferences
+                </DropdownItem>
+                <DropdownItem divider />
+                <DropdownItem href="/signout/:id">
+                  Sign out
+                </DropdownItem>
+              </DropdownMenu>
+              </React.Fragment>
+);
+
+export default Dropdown;

--- a/ui/src/Components/EditProfile.jsx
+++ b/ui/src/Components/EditProfile.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Button, Col, Form, FormGroup, Label, Input} from 'reactstrap';
+import { Button, Col, FormGroup, Label, Input} from 'reactstrap';
+import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Loading } from './auth/Loading';
 
-//URLs for PUT CALL
-// const ApiUrl = "http://localhost:3001/dev/editProfile";
+
+//Uncomment/Comment based on env
+//const ApiUrl = "http://localhost:3001/dev/editProfile";
 const ApiUrl = "https://bixe448nsa.execute-api.us-west-1.amazonaws.com/dev/editProfile";
 
 //URLS for GET CALL
@@ -20,40 +22,62 @@ const uploadCopy = "Save";
 class CreateProfile extends React.Component {
     constructor(props) {
         super(props);
-
+        
         this.state = {
-            loading: true,
             profile: null,
+            loading: true,
             props: props,
             firstName: '',
+            middleName: '',
             lastName: '',
             email: '',
+            address: '',
+            city: '',
+            postal: '',
+            province: '',
+            dob: '',
             number: '',
             profile_id: '',
+            sin: '',
+            currentOccupation: '',
             ref1Name: '',
             ref1Email: '',
+            ref1Relationship: '',
             ref2Name: '',
             ref2Email: '',
+            ref2Relationship: '',
             govIdFlag: false,
             govId: null,
             toolPicFlag: false,
             toolPic: null,
+            hinFlag: false,
+            hinPic: null,
             readyForVerification:0,
         };
 
         this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
+        this.handleMiddleNameChange = this.handleMiddleNameChange.bind(this);
         this.handleLastNameChange = this.handleLastNameChange.bind(this);
         this.handleEmailChange = this.handleEmailChange.bind(this);
+        this.handleAddressChange = this.handleAddressChange.bind(this);
+        this.handleCityChange = this.handleCityChange.bind(this);
+        this.handlePostalChange = this.handlePostalChange.bind(this);
+        this.handleProvinceChange = this.handleProvinceChange.bind(this);
+        this.handleDobChange = this.handleDobChange.bind(this);
+        this.handleSinChange = this.handleSinChange.bind(this);
+        this.handleCurrentOccupationChange = this.handleCurrentOccupationChange.bind(this);
         this.handleNumChange = this.handleNumChange.bind(this);
         this.handleRef1NameChange = this.handleRef1NameChange.bind(this);
         this.handleRef1EmailChange = this.handleRef1EmailChange.bind(this);
+        this.handleRef1RelationshipChange = this.handleRef1RelationshipChange.bind(this);
         this.handleRef2NameChange = this.handleRef2NameChange.bind(this);
         this.handleRef2EmailChange = this.handleRef2EmailChange.bind(this);
+        this.handleRef2RelationshipChange = this.handleRef2RelationshipChange.bind(this);
         this.handleLicenseUpload = this.handleLicenseUpload.bind(this);
         this.handleToolUpload = this.handleToolUpload.bind(this);
+        this.handleHinUpload = this.handleHinUpload.bind(this);
         this.handleAppStatusUpdate = this.handleAppStatusUpdate.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-
     }
 
     // Get information to populate the profile before editing
@@ -70,7 +94,37 @@ class CreateProfile extends React.Component {
       this.state.number = this.state.profile.result.contact_num;
     }
 
-    // functions to handle method update
+    handleSinChange(event) {
+        this.setState({sin: event.target.value});
+    }
+    handleCurrentOccupationChange(event) {
+        this.setState({currentOccupation: event.target.value});
+    }
+
+    handleDobChange(event) {
+        this.setState({dob: event.target.value});
+    }
+
+    handleProvinceChange(event) {
+        this.setState({province: event.target.value});
+    }
+
+    handlePostalChange(event) {
+        this.setState({postal: event.target.value});
+    }
+
+    handleCityChange(event) {
+        this.setState({city: event.target.value});
+    }
+    
+    handleAddressChange(event) {
+        this.setState({address: event.target.value});
+    }
+
+    handleMiddleNameChange(event) {
+        this.setState({middleName: event.target.value});
+    }
+
     handleFirstNameChange(event) {
         this.setState({firstName: event.target.value});
     }
@@ -84,7 +138,7 @@ class CreateProfile extends React.Component {
     }
 
     handleLastNameChange(event) {
-            this.setState({lastName: event.target.value});
+        this.setState({lastName: event.target.value});
     }
 
     handleEmailChange(event) {
@@ -111,6 +165,14 @@ class CreateProfile extends React.Component {
         this.setState({ref2Email: event.target.value});
     }
 
+    handleRef1RelationshipChange(event) {
+        this.setState({ref1Relationship: event.target.value});
+    }
+
+    handleRef2RelationshipChange(event) {
+        this.setState({ref2Relationship: event.target.value});
+    }
+
     handleLicenseUpload(event) {
         this.setState({
             govIdFlag: true,
@@ -122,6 +184,13 @@ class CreateProfile extends React.Component {
         this.setState({
             toolPicFlag: true,
             toolPic: event.target.files[0]
+        });
+    }
+    
+    handleHinUpload(event) {
+        this.setState({
+            hinFlag: true,
+            hinPic: event.target.files[0]
         });
     }
 
@@ -136,7 +205,7 @@ class CreateProfile extends React.Component {
         if(this.state.number  == ""){
             this.state.number = this.state.profile.result.contact_num;         
         }     
-        if(this.state.number  == ""){
+        if(this.state.email  == ""){
             this.state.email = this.state.profile.result.email; 
         }  
     };
@@ -153,15 +222,26 @@ class CreateProfile extends React.Component {
                 },
               body: JSON.stringify( { 
                 firstName:this.state.firstName, 
+                middleName:this.state.middleName, 
                 lastName:this.state.lastName,
-                email:this.state.email, 
-                number:this.state.number, 
+                address:this.state.address,
+                city:this.state.city,
+                postal: this.state.postal,
+                province: this.state.province,
+                dob: this.state.dob,
+                sin: this.state.sin,
+                currentOccupation: this.state.currentOccupation,
+                email: this.state.email, 
+                number: this.state.number, 
                 reference1Name:this.state.ref1Name,
                 reference1Email:this.state.ref1Email,
+                reference1Relationship:this.state.ref1Relationship,
                 reference2Name:this.state.ref2Name,
                 reference2Email:this.state.ref2Email,
+                reference2Relationship:this.state.ref2Relationship,
                 govId:this.state.govIdFlag,
                 toolPic:this.state.toolPicFlag,
+                hinFlag:this.state.hinFlag,
                 id:this.state.props.match.params.id, //added profile ID to payload
                 readyForVerification: this.state.readyForVerification,
                 }),
@@ -202,87 +282,148 @@ class CreateProfile extends React.Component {
         }
         if (this.state.loading) {
             return <Loading />
-            } else {
-                return (
-                    <>
-                    {!this.state.profile ? (
-                        <div> Profile Does Not Exist </div>
-                    ) : (
-                        <Form onSubmit={ this.handleSubmit }>
-                        <div className="row-buffer side-buffer">
-                        <FormGroup className="left-align" row>
-                        <Label for="name" sm={2}><h4>Edit Profile</h4></Label>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label for="name" sm={2}>First Name</Label>
-                            <Col sm={10}>
-                            <Input type="text" name="name" id="firstname" placeholder={this.state.profile.result.first_name} onChange={this.handleFirstNameChange} value={this.state.firstName}/>
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label for="name" sm={2}>Last Name</Label>
-                            <Col sm={10}>
-                            <Input type="text" name="name" id="lastname" placeholder={this.state.profile.result.last_name} onChange={this.handleLastNameChange} value={this.state.lastName}/>
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label for="email" sm={2}>Email</Label>
-                            <Col sm={10}>
-                            <Input type="email" name="email" id="email" placeholder={this.state.profile.result.email}  onChange={this.handleEmailChange} value={this.state.email}/>
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label for="phone" sm={2}>Phone Number</Label>
-                            <Col sm={10}>
-                            <Input type="tel" name="phone" id="phone" placeholder={this.state.profile.result.contact_num} onChange={this.handleNumChange} value={this.state.number}/>
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label for="govId" sm={2}>Government Issued ID</Label>
-                            <Col sm={10}>
-                            <Input type="file" name="govId" id="govId" onChange={this.handleLicenseUpload}/>
-                            </Col>
-                        </FormGroup>
-                        {/** NOT CURRENTLY RETURNED IN GET CALL - FUTURE SPRINT WORK */}
-                        <FormGroup className="left-align" row>
-                            <Label sm={2}>Reference 1:</Label>
-                            <Label for="referenceName" sm={1}>Name</Label>
-                            <Col sm={4}>
-                            <Input type="text" name="referenceName" id="referenceName" onChange={this.handleRef1NameChange} value={this.state.ref1Name}/>
-                            </Col>
-                            <Label for="referenceEmail" sm={1}>Email</Label>
-                            <Col sm={4}>
-                            <Input type="email" name="referenceEmail" id="referenceEmail" onChange={this.handleRef1EmailChange} value={this.state.ref1Email}/>
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="left-align" row>
-                            <Label sm={2}>Reference 2:</Label>
-                            <Label for="referenceName" sm={1}>Name</Label>
-                            <Col sm={4}>
-                            <Input type="text" name="referenceName" id="referenceName" onChange={this.handleRef2NameChange} value={this.state.ref2Name}/>
-                            </Col>
-                            <Label for="referenceEmail" sm={1}>Email</Label>
-                            <Col sm={4}>
-                            <Input type="email" name="referenceEmail" id="referenceEmail" onChange={this.handleRef2EmailChange} value={this.state.ref2Email}/>
-                            </Col>
-                        </FormGroup>
-                        {checkToolFile()}
-                        <FormGroup className="left-align" row>
-                            <Label for="tools" sm={2} >Tools/Supplies</Label>
-                            <Col sm={10}>
-                            <Input type="file" name="tools" id="tools" onChange={this.handleToolUpload} />
-                            </Col>
-                        </FormGroup>
-                        <FormGroup className="right-align" check row>
-                            <Button type="submit" name="false" onClick={this.handleAppStatusUpdate } style={{margin: '5px'}}>{uploadCopy}</Button> 
-                            <Button type="submit" name="true" onClick={this.handleAppStatusUpdate} style={{backgroundColor: '#4CAF50'}}>{readyForVerificationCopy}</Button>
-                        </FormGroup>
-                        </div>
-                    </Form>
-                    )}
-                    </>
-                );
-            }
+           } else {
+               return (
+                   <>
+                   {!this.state.profile ? (
+                       <div> Profile Does Not Exist </div>
+                   ) : (
+                    <AvForm onSubmit={ this.handleSubmit }>
+                    <div class="row-buffer side-buffer">
+                    <FormGroup row>
+                    <Label sm={2}><h4 className="left-align" >Complete Profile</h4></Label>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="firstName" sm={2}>First Name</Label>
+                        <Col sm={10}>
+                        <AvField name="firstName" type="text" placeholder="John" onChange={this.handleFirstNameChange} value={this.state.firstName} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="middleName" sm={2}>Middle Name</Label>
+                        <Col sm={10}>
+                        <AvField name="middleName" type="text" placeholder="Doe" onChange={this.handleMiddleNameChange} value={this.state.middleName} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="lastName" sm={2}>Last Name</Label>
+                        <Col sm={10}>
+                        <AvField name="lastName" type="text" placeholder="Arelli" onChange={this.handleLastNameChange} value={this.state.lastName} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="dob" sm={2}>Date of Birth</Label>
+                        <Col sm={10}>
+                        <AvField name="dob" type="date" placeholder="mm/dd/yyyy" onChange={this.handleDobChange} value={this.state.dob} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="sin" sm={2}>Social Insurance Number</Label>
+                        <Col sm={10}>
+                        <AvField name="sin" type="number" placeholder="123456789" maxLength={9} minLength={9} onChange={this.handleSinChange} value={this.state.sin} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="email" sm={2}>Email</Label>
+                        <Col sm={10}>
+                        <AvField name="email" type="email" placeholder="johndoe@gmail.com" onChange={this.handleEmailChange} value={this.state.email} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="number" sm={2}>Phone Number</Label>
+                        <Col sm={10}>
+                        <AvField name="number" type="tel" placeholder="415-879-7877" onChange={this.handleNumChange} value={this.state.number} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="address" sm={2}>Address</Label>
+                        <Col sm={10}>
+                        <AvField name="address" type="text" placeholder="100 Reindeer Street" onChange={this.handleAddressChange} value={this.state.address} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="city" sm={2}>City</Label>
+                        <Col sm={10}>
+                        <AvField name="city" type="text" placeholder="North Pole" onChange={this.handleCityChange} value={this.state.city} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="postal" sm={2}>Postal Code</Label>
+                        <Col sm={10}>
+                        <AvField name="postal" type="text" placeholder="H0H 0H0" onChange={this.handlePostalChange} value={this.state.postal} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="province" sm={2}>Province</Label>
+                        <Col sm={10}>
+                        <AvField name="province" type="text" placeholder="Arctic Circle" onChange={this.handleProvinceChange} value={this.state.province} required />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="currentOccupation" sm={2}>Current Occupation</Label>
+                        <Col sm={10}>
+                        <AvField name="currentOccupation" type="text" placeholder="Student" onChange={this.handleCurrentOccupationChange} value={this.state.currentOccupation} required />
+                        </Col>
+                    </FormGroup>
+                    
+                    <FormGroup className="left-align" row>
+                        <Label sm={2}>Reference 1:</Label>
+                        <Label for="ref1Name" sm={1}>Name</Label>
+                        <Col sm={2}>
+                        <Input type="text" name="ref1Name" id="referenceName" onChange={this.handleRef1NameChange} value={this.state.ref1Name}/>
+                        </Col>
+                        <Label for="ref1Email" sm={1}>Email</Label>
+                        <Col sm={2}>
+                        <Input type="email" name="ref1Email" id="referenceEmail" onChange={this.handleRef1EmailChange} value={this.state.ref1Email}/>
+                        </Col>
+                        <Label for="ref1Relationship" sm={1}>Relationship</Label>
+                        <Col sm={2}>
+                        <Input type="text" name="ref1Email" id="referenceRelationship" onChange={this.handleRef1RelationshipChange} value={this.state.ref1Relationship}/>
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label sm={2}>Reference 2:</Label>
+                        <Label for="ref2Name" sm={1}>Name</Label>
+                        <Col sm={2}>
+                        <Input type="text" name="ref2Name" id="referenceName" onChange={this.handleRef2NameChange} value={this.state.ref2Name}/>
+                        </Col>
+                        <Label for="ref2Email" sm={1}>Email</Label>
+                        <Col sm={2}>
+                        <Input type="email" name="ref2Email" id="referenceEmail" onChange={this.handleRef2EmailChange} value={this.state.ref2Email}/>
+                        </Col>
+                        <Label for="ref2Relationship" sm={1}>Relationship</Label>
+                        <Col sm={2}>
+                        <Input type="text" name="ref2Relationship" id="referenceRelationship" onChange={this.handleRef2RelationshipChange} value={this.state.ref2Relationship}/>
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="hin" sm={2}>Proof of Health Insurance</Label>
+                        <Col sm={10}>
+                        <AvField name="hin" type="file" onChange={this.handleHinUpload} />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="govId" sm={2}>Government Issued ID</Label>
+                        <Col sm={10}>
+                        <AvField name="govId" type="file" onChange={this.handleLicenseUpload} />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="left-align" row>
+                        <Label for="tools" sm={2}>Tools/Supplies</Label>
+                        <Col sm={10}>
+                        <AvField type="file" name="tools" id="tools" onChange={this.handleToolUpload} />
+                        </Col>
+                    </FormGroup>
+                    <FormGroup className="right-align" check row>
+                        <Button className="btn btn-secondary" type="submit">Submit</Button>
+                    </FormGroup>
+                </div>
+                </AvForm>
+                   )}
+                   </>
+               );
+           }
+
     }
 }
 

--- a/ui/src/Components/EditProfile.jsx
+++ b/ui/src/Components/EditProfile.jsx
@@ -38,7 +38,7 @@ class CreateProfile extends React.Component {
         this.handleRef1NameChange = this.handleRef1NameChange.bind(this);
         this.handleRef1EmailChange = this.handleRef1EmailChange.bind(this);
         this.handleRef2NameChange = this.handleRef2NameChange.bind(this);
-        this.handleRef1EmailChange = this.handleRef2EmailChange.bind(this);
+        this.handleRef2EmailChange = this.handleRef2EmailChange.bind(this);
         this.handleLicenseUpload = this.handleLicenseUpload.bind(this);
         this.handleToolUpload = this.handleToolUpload.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);

--- a/ui/src/Components/HomePage.jsx
+++ b/ui/src/Components/HomePage.jsx
@@ -9,62 +9,59 @@ const HomePage = () => {
     return (
         <React.Fragment>
             <Container>
-                <p class="row-buffer">The Academy of Cleaning empowers cleaners like you to find new business.
+                <p className="row-buffer">The Academy of Cleaning empowers cleaners like you to find new business.
                 <br />Start your application and get your industry standard cleaning certification today!</p>
             </Container>
 
             <Container>
-                <h4 class="row-buffer">Certifications Offered</h4>
-                <div class="row">
-                    <div class="column">
-                        <CardImg  class="image" src="https://media.istockphoto.com/photos/window-cleaning-picture-id162353089?k=6&m=162353089&s=612x612&w=0&h=OcI9R5ilQk_UmgM_kPHg4dCftVIzRsmTIbxJefGPSfM="alt="Windows 101" />
-                        <div class="overlay">
-                          <div class="text">Windows 101 </div>
+                <h4 className="row-buffer">Certifications Offered</h4>
+                <div className="row">
+                    <div className="column">
+                        <CardImg  className="image" src="https://media.istockphoto.com/photos/window-cleaning-picture-id162353089?k=6&m=162353089&s=612x612&w=0&h=OcI9R5ilQk_UmgM_kPHg4dCftVIzRsmTIbxJefGPSfM="alt="Windows 101" />
+                        <div className="overlay">
+                          <div className="text">Windows 101 </div>
                         </div>
                     </div>
-                    <div class="column">
-                        <CardImg class="image" src="https://media.istockphoto.com/photos/one-man-in-protective-suit-spraying-the-house-and-disinfecting-the-picture-id1212734713?k=6&m=1212734713&s=612x612&w=0&h=q80feozY2WtresZvCMgRlk7OfYbcb1KMYrGHbbgvnMo="alt="Sanitization 101" />
-                        <div class="overlay">
-                          <div class="text">Sanitation 101 </div>
+                    <div className="column">
+                        <CardImg className="image" src="https://media.istockphoto.com/photos/one-man-in-protective-suit-spraying-the-house-and-disinfecting-the-picture-id1212734713?k=6&m=1212734713&s=612x612&w=0&h=q80feozY2WtresZvCMgRlk7OfYbcb1KMYrGHbbgvnMo="alt="Sanitization 101" />
+                        <div className="overlay">
+                          <div className="text">Sanitation 101 </div>
                         </div>
                     </div>
-                    <div class="column">
-                        <CardImg class="image" src="https://media.istockphoto.com/photos/woman-mopping-corridor-picture-id591406230?k=6&m=591406230&s=612x612&w=0&h=0ZLygrIeHJFwj9d95GJZImj5SaFT6fuetMlKp-m_lTo=" alt="Mopping 101" />
-                        <div class="overlay">
-                          <div class="text">Mopping 101 </div>
+                    <div className="column">
+                        <CardImg className="image" src="https://media.istockphoto.com/photos/woman-mopping-corridor-picture-id591406230?k=6&m=591406230&s=612x612&w=0&h=0ZLygrIeHJFwj9d95GJZImj5SaFT6fuetMlKp-m_lTo=" alt="Mopping 101" />
+                        <div className="overlay">
+                          <div className="text">Mopping 101 </div>
                         </div>
                     </div>
                     
                 </div>
-                <div class="row">
-                    <div class="column">
-                        <CardImg class="image" src="https://media.istockphoto.com/photos/cleaning-the-floor-picture-id578562734?k=6&m=578562734&s=612x612&w=0&h=UvjjCgBaiqHWQfr-a7Zrl43AAhi6Fy3_ZnkGUlP8tGM=" alt="Floor Polishing 101" />
-                        <div class="overlay">
-                          <div class="text">Floor Polishing 101 </div>
+                <div className="row">
+                    <div className="column">
+                        <CardImg className="image" src="https://media.istockphoto.com/photos/cleaning-the-floor-picture-id578562734?k=6&m=578562734&s=612x612&w=0&h=UvjjCgBaiqHWQfr-a7Zrl43AAhi6Fy3_ZnkGUlP8tGM=" alt="Floor Polishing 101" />
+                        <div className="overlay">
+                          <div className="text">Floor Polishing 101 </div>
                         </div>
                     </div>
-                    <div class="column">
-                        <CardImg class="image" src="https://media.istockphoto.com/photos/woman-cleaning-a-corporate-kitchen-picture-id175443686?k=6&m=175443686&s=612x612&w=0&h=dniEs4frt3aZo71BCGe94GmJ_r-9NZUW2fJOFXkuo4Q=" alt="Dusting 101" />
-                        <div class="overlay">
-                          <div class="text">Dusting 101 </div>
+                    <div className="column">
+                        <CardImg className="image" src="https://media.istockphoto.com/photos/woman-cleaning-a-corporate-kitchen-picture-id175443686?k=6&m=175443686&s=612x612&w=0&h=dniEs4frt3aZo71BCGe94GmJ_r-9NZUW2fJOFXkuo4Q=" alt="Dusting 101" />
+                        <div className="overlay">
+                          <div className="text">Dusting 101 </div>
                         </div>
                     </div>
-                    <div class="column">
-                        <CardImg class="image" src="https://media.istockphoto.com/photos/steam-cleaning-the-office-carpet-picture-id518333126?k=6&m=518333126&s=612x612&w=0&h=d4zb40OCItBcugylWPs4KneFI_tpJUKwTXWnffeQtvg=" alt="Carpet Cleaning 101" />
-                        <div class="overlay">
-                          <div class="text">Carpet Steaming 101 </div>
+                    <div className="column">
+                        <CardImg className="image" src="https://media.istockphoto.com/photos/steam-cleaning-the-office-carpet-picture-id518333126?k=6&m=518333126&s=612x612&w=0&h=d4zb40OCItBcugylWPs4KneFI_tpJUKwTXWnffeQtvg=" alt="Carpet Cleaning 101" />
+                        <div className="overlay">
+                          <div className="text">Carpet Steaming 101 </div>
                         </div>
                     </div>                    
                 </div>
             </Container>
-            <div class="row-buffer">
+            <div className="row-buffer">
             <p>Start the Journey Today</p>
                 <Link to= {`/profiles/create`}className="btn btn-outline-success">Get Started</Link>
-                <button class="btn"> <AuthNav /></button>
+                <button className="btn"> <AuthNav /></button>
             </div>
-
-
-
         </React.Fragment>
     );
 }

--- a/ui/src/Components/NavBar.jsx
+++ b/ui/src/Components/NavBar.jsx
@@ -10,11 +10,10 @@ import {
   UncontrolledDropdown,
   DropdownToggle,
   DropdownMenu,
-  DropdownItem,
-  NavbarText
+  DropdownItem
 } from 'reactstrap';
+import NavBarAuthenticationButton from './NavBarAuthenticationButton';
 import './App.css';
-
 
 const NavBar = (props) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -56,7 +55,8 @@ const NavBar = (props) => {
             </UncontrolledDropdown>
 
             <UncontrolledDropdown>
-              <DropdownToggle nav caret>
+              <NavBarAuthenticationButton />
+              {/* <DropdownToggle nav caret>
                 My Account
               </DropdownToggle>
               <DropdownMenu right>
@@ -70,7 +70,7 @@ const NavBar = (props) => {
                 <DropdownItem href="/signout/:id">
                   Sign out
                 </DropdownItem>
-              </DropdownMenu>
+              </DropdownMenu> */}
             </UncontrolledDropdown>
           </Nav>
         </Collapse>

--- a/ui/src/Components/NavBarAuthenticationButton.jsx
+++ b/ui/src/Components/NavBarAuthenticationButton.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import './App.css';
+import LoginButton from './auth/LoginButton';
+import Dropdown from './Dropdown';
+import { useAuth0 } from "@auth0/auth0-react";
+
+
+const NavBarAuthenticationButton = () => {
+  const { isAuthenticated } = useAuth0();
+
+  return isAuthenticated ? <Dropdown /> : <LoginButton />;
+};
+
+export default NavBarAuthenticationButton;

--- a/ui/src/Components/ProfilePage.jsx
+++ b/ui/src/Components/ProfilePage.jsx
@@ -62,7 +62,7 @@ export default class ProfilePage extends React.Component {
               {this.state.profile.result.city ? <H4>Servicing the {this.state.profile.result.city} area</H4> : <div/>}
               <Table className="row-buffer" responsive>
                 <tbody>
-                <tr>
+                  <tr>
                     <td>Email</td>
                     <td>{this.state.profile.result.email}</td>
                   </tr>
@@ -79,7 +79,7 @@ export default class ProfilePage extends React.Component {
                     <td>{this.state.profile.result.city}</td>
                   </tr>
                   {this.state.profile.result.has_tools ? (
-                    <tr>
+                  <tr>
                     <td>Tool Pictures</td>
                     <td><a target="_blank" href={toolPicUrl + this.state.profile.result.profile_id + '.pdf'}>Tool Picture Link</a></td>
                   </tr>
@@ -96,7 +96,6 @@ export default class ProfilePage extends React.Component {
             </div>
           )}
         </Form>
-        
       </div>
     );
     }


### PR DESCRIPTION
This PR:
- [x] fixes the bug from last sprint which disabled a new user from successfully creating their profile
- [x] updates the front-end create profile form to include numerous new fields which enrich the User Experience
- [x] updates the `/createProfile` API to accept the new data that is to be inserted into the database
- [x] API now persists references to `reference` and `has_reference` table
- [x] adds some more validation to the fields on the create profile form
- [x] date picker for date of birth!

Screenshot of the updated create profile page (`/createProfile`)
<img width="1280" alt="Screen Shot 2020-12-06 at 7 22 30 PM" src="https://user-images.githubusercontent.com/35209054/101297727-76d4b280-37f8-11eb-8176-ed30ab8973d4.png">
